### PR TITLE
Endepunkt for å hente ut en signed clientassertion.

### DIFF
--- a/src/main/kotlin/no/nav/tms/auth/mock/tokendings/ClientAssertion.kt
+++ b/src/main/kotlin/no/nav/tms/auth/mock/tokendings/ClientAssertion.kt
@@ -1,0 +1,41 @@
+package no.nav.tms.auth.mock.tokendings
+
+import com.nimbusds.jose.JOSEObjectType
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.RSASSASigner
+import com.nimbusds.jose.jwk.RSAKey
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import no.nav.tms.auth.mock.common.JwkBuilder
+import java.time.Instant
+import java.util.*
+
+internal object ClientAssertion {
+
+    fun createSignedAssertion(clientId: String, audience: String): String {
+        val now = Date.from(Instant.now())
+        val privateRsaKey = RSAKey.parse(JwkBuilder.generateJwkString())
+        return JWTClaimsSet.Builder()
+            .issuer(clientId)
+            .subject(clientId)
+            .audience(audience)
+            .issueTime(now)
+            .expirationTime(Date.from(Instant.now().plusSeconds(60)))
+            .jwtID(UUID.randomUUID().toString())
+            .build()
+            .sign(privateRsaKey)
+            .serialize()
+    }
+
+    private fun JWTClaimsSet.sign(rsaKey: RSAKey): SignedJWT =
+        SignedJWT(
+            JWSHeader.Builder(JWSAlgorithm.RS256)
+                .keyID(rsaKey.keyID)
+                .type(JOSEObjectType.JWT).build(),
+            this
+        ).apply {
+            sign(RSASSASigner(rsaKey.toPrivateKey()))
+        }
+
+}

--- a/src/main/kotlin/no/nav/tms/auth/mock/tokendings/tokendingsApi.kt
+++ b/src/main/kotlin/no/nav/tms/auth/mock/tokendings/tokendingsApi.kt
@@ -6,6 +6,7 @@ import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.util.pipeline.*
+import no.nav.tms.auth.mock.tokendings.ClientAssertion.createSignedAssertion
 
 fun Route.tokenApi(
     tokendingsMetadataBuilder: TokendingsMetadataBuilder,
@@ -21,6 +22,17 @@ fun Route.tokenApi(
         val metadata = tokendingsMetadataBuilder.createJwksMetadata()
 
         call.respond(metadata)
+    }
+
+    get("/tokendings/clientassertion") {
+        val params = call.request.queryParameters
+        val clientId = params["clientId"]
+        val audience = params["audience"]
+        if(clientId != null && audience != null) {
+            call.respond(createSignedAssertion(clientId, audience))
+        } else {
+            call.respond(HttpStatusCode.BadRequest)
+        }
     }
 
     post("/tokendings/token") {
@@ -60,3 +72,4 @@ private suspend fun ApplicationCall.receiveTokendingsParams(): TokendingsParams?
         TokendingsParams(clientAssertion, subjectToken, audience)
     }
 }
+


### PR DESCRIPTION
Nødvendig for e2e-tester som bruker endepunkter som forventer et TokenX-token. 